### PR TITLE
Reduce allocations

### DIFF
--- a/src/scattered_uv.jl
+++ b/src/scattered_uv.jl
@@ -10,8 +10,8 @@ function allocate_scattered_radiation()
         quad_weights  = zeros(101),
         γᵣ = zeros(101),
         γₗ = zeros(101),
-        # Pre-allocated AI scratch (overwritten each call to scattered_radiation!).
-        AI = MVector{30,Float64}(undef),
+        # Pre-allocated auxiliary_terms scratch (overwritten each call to scattered_radiation!).
+        auxiliary_terms = MVector{30,Float64}(undef),
         chandrasekhar_XY_buffers = init_chandrasekhar_XY_buffers(),
     )
 end
@@ -20,7 +20,8 @@ scattered_radiation(τ::Float64) = scattered_radiation!(allocate_scattered_radia
 
 function scattered_radiation!(buffers, τ::Float64)
     # Large arrays (mutable, normal)
-    (; μ, X1, Y1, X2, Y2, quad_weights, γᵣ, γₗ, AI, chandrasekhar_XY_buffers) = buffers
+    (; μ, X1, Y1, X2, Y2, quad_weights, γᵣ, γₗ, chandrasekhar_XY_buffers) = buffers
+    AI = buffers.auxiliary_terms  # short alias for the math below
 
     # Set up μ array
     μ[1] = 0.0
@@ -83,7 +84,7 @@ function scattered_radiation!(buffers, τ::Float64)
         xb8 += term4 * μ3
     end
 
-    # Fill AI vector
+    # Fill AI (auxiliary terms) vector
     AI[1]  = xb1 + xb5 - 8.0 / 3.0
     AI[2]  = xb2 + xb6
     AI[3]  = xb3 + xb7

--- a/src/scattered_uv.jl
+++ b/src/scattered_uv.jl
@@ -10,6 +10,8 @@ function allocate_scattered_radiation()
         quad_weights  = zeros(101),
         γᵣ = zeros(101),
         γₗ = zeros(101),
+        # Pre-allocated AI scratch (overwritten each call to scattered_radiation!).
+        AI = MVector{30,Float64}(undef),
         chandrasekhar_XY_buffers = init_chandrasekhar_XY_buffers(),
     )
 end
@@ -18,10 +20,7 @@ scattered_radiation(τ::Float64) = scattered_radiation!(allocate_scattered_radia
 
 function scattered_radiation!(buffers, τ::Float64)
     # Large arrays (mutable, normal)
-    (; μ, X1, Y1, X2, Y2, quad_weights, γᵣ, γₗ, chandrasekhar_XY_buffers) = buffers
-
-    # Small fixed-size arrays (use StaticArrays)
-    AI  = @MVector zeros(30)
+    (; μ, X1, Y1, X2, Y2, quad_weights, γᵣ, γₗ, AI, chandrasekhar_XY_buffers) = buffers
 
     # Set up μ array
     μ[1] = 0.0
@@ -155,6 +154,15 @@ function init_chandrasekhar_XY_buffers()
         Y_approx = zeros(101),
         X = zeros(101),
         Y = zeros(101),
+        # Small fixed-size scratch buffers — these are re-overwritten on every
+        # call. Hoisting them out of the hot path avoids ~6 MVector allocations
+        # per `chandrasekhar_xy!` invocation.
+        μ_roots = MVector{5,Float64}(undef),
+        cap_a_coeffs = MVector{5,Float64}(undef),
+        temp_X = MVector{8,Float64}(undef),
+        temp_Y = MVector{8,Float64}(undef),
+        k_roots = MVector{5,Float64}(undef),
+        λ = MVector{5,Float64}(undef),
     )
     return arrays
 end
@@ -220,12 +228,13 @@ function chandrasekhar_xy!(buffers, τ::Float64, characteristic_function_coeffs:
     μ   = buffers.μ
     quad_weights_Xa    = buffers.quad_weights_Xa
     quad_weights_Xb    = buffers.quad_weights_Xb
-    μ_roots  = @MVector zeros(5)
-    cap_a_coeffs = @MVector zeros(5)
-    temp_X = @MVector zeros(8)
-    temp_Y = @MVector zeros(8)
-    k_roots  = @MVector zeros(5)
-    λ = @MVector zeros(5)
+    # Pre-allocated MVector scratch (overwritten in full each call).
+    μ_roots  = buffers.μ_roots
+    cap_a_coeffs = buffers.cap_a_coeffs
+    temp_X = buffers.temp_X
+    temp_Y = buffers.temp_Y
+    k_roots  = buffers.k_roots
+    λ = buffers.λ
     fn_plus_p  = buffers.fn_plus_p
     fn_plus_n  = buffers.fn_plus_n
     fn_c0  = buffers.fn_c0

--- a/src/solar_radiation.jl
+++ b/src/solar_radiation.jl
@@ -304,9 +304,12 @@ Returns `(; tanδ_tanϕ, H₊, H₋)`:
 - `H₋`: Hour angle at sunrise (hours)
 """
 function sunrise_hour_angle(δ, ϕ)
-    # `δ` is plain Float64 in radians (from `acos`); `ϕ` may be a Quantity{°}.
-    # ustrip-ing into pure Float64 avoids the per-call Unitful runtime
-    # conversion that boxes intermediate Float64s.
+    # TODO: this manual ustrip shouldn't be needed — degrees aren't a "real"
+    # unit and `tan(::Quantity{°})` ought to be allocation-free. In practice
+    # it goes through a Unitful conversion path that heap-allocates ~8
+    # intermediate Float64s per call. Worth investigating in Unitful (or
+    # dropping `Quantity{°}` from the SolarTerrain API entirely). Workaround
+    # in the meantime: ustrip ϕ once into Float64 radians.
     ϕ_rad = ustrip(u"°", ϕ) * (π / 180.0)
     tanδ_tanϕ = -tan(δ) * tan(ϕ_rad)
     H₊ = abs(tanδ_tanϕ) >= 1 ? π : abs(acos(tanδ_tanϕ))

--- a/src/solar_radiation.jl
+++ b/src/solar_radiation.jl
@@ -45,14 +45,17 @@ Calculate the effective zenith angle on the terrain surface.
 On flat terrain (slope = 0°) returns the solar zenith angle unchanged.
 On sloped terrain adjusts for slope and aspect using Eq. 3.15 of Sellers (1965).
 """
-function slope_zenith_angle(z, terrain::AbstractTerrain, solar_azimuth)
+@inline function slope_zenith_angle(z, terrain::AbstractTerrain, solar_azimuth)
     if terrain.slope > 0u"°"
         czsl = cos(z) * cos(terrain.slope) + sin(z) * sin(terrain.slope) * cos(solar_azimuth - terrain.aspect)
         zsl = acos(czsl)
         zsl = min(uconvert(u"°", zsl), 90u"°")  # cap at 90° if sun is below slope horizon
     else
         czsl = cos(z)
-        zsl = uconvert(u"°", z * u"rad")
+        # `z` is a plain Float64 in radians (from `acos(cosZ)`); avoid the
+        # `uconvert(u"°", z * u"rad")` round-trip which heap-allocates a
+        # transient Quantity{rad} per call.
+        zsl = (z * (180.0 / π)) * u"°"
     end
     return (; zenith_angle=zsl, cosine_zenith=czsl)
 end
@@ -200,8 +203,18 @@ end
 Look up the horizon angle at a given solar azimuth.
 """
 function horizon_angle_at_azimuth(solar_azimuth, horizon_angles)
-    azi = range(0u"°", stop=360u"°" - 360u"°" / length(horizon_angles), length=length(horizon_angles))
-    return horizon_angles[argmin(abs.(solar_azimuth .- azi))]
+    n = length(horizon_angles)
+    step = 360u"°" / n
+    best_idx = 1
+    best_diff = abs(solar_azimuth - 0u"°")
+    @inbounds for i in 2:n
+        diff = abs(solar_azimuth - (i - 1) * step)
+        if diff < best_diff
+            best_diff = diff
+            best_idx = i
+        end
+    end
+    return @inbounds horizon_angles[best_idx]
 end
 
 """
@@ -233,7 +246,10 @@ function allocate_output_arrays(nsteps, ndays, nmax)
     return (;
         zenith_angle = fill(90.0u"°", nsteps),
         zenith_slope_angle = fill(90.0u"°", nsteps),
-        azimuth_angle = fill!(Vector{Union{Missing,typeof(0.0u"°")}}(undef, nsteps), 90.0u"°"),
+        # 90° is the sun-below-horizon sentinel; using a plain Vector{Quantity{°}}
+        # avoids the Union{Missing,...} boxing that would heap-allocate every
+        # azimuth write inside the per-step loop.
+        azimuth_angle = fill(90.0u"°", nsteps),
         hour_angle_sunrise = fill(0.0, ndays),
         hour_solar_noon = fill(0.0, ndays),
         day_of_year = Vector{Int}(undef, nsteps),
@@ -288,7 +304,11 @@ Returns `(; tanδ_tanϕ, H₊, H₋)`:
 - `H₋`: Hour angle at sunrise (hours)
 """
 function sunrise_hour_angle(δ, ϕ)
-    tanδ_tanϕ = -tan(δ) * tan(ϕ)
+    # `δ` is plain Float64 in radians (from `acos`); `ϕ` may be a Quantity{°}.
+    # ustrip-ing into pure Float64 avoids the per-call Unitful runtime
+    # conversion that boxes intermediate Float64s.
+    ϕ_rad = ustrip(u"°", ϕ) * (π / 180.0)
+    tanδ_tanϕ = -tan(δ) * tan(ϕ_rad)
     H₊ = abs(tanδ_tanϕ) >= 1 ? π : abs(acos(tanδ_tanϕ))
     H₋ = 12.0 * H₊ / π
     return (; tanδ_tanϕ, H₊, H₋)
@@ -385,7 +405,10 @@ function solar_radiation!(out, buffers, solar_model::AbstractSolarRadiation;
             H₋ = sunrise.H₋
             sun_up = is_sun_up(t - tsn, H₋)
 
-            solar_azimuth = missing
+            # 90° = sun-below-horizon sentinel (matches the Vector pre-fill);
+            # avoids `Union{Missing, Quantity{°}}` typing of `solar_azimuth`
+            # which would force boxing through the slope_zenith_angle call below.
+            solar_azimuth = 90.0u"°"
             if sun_up || sunrise.tanδ_tanϕ == 1
                 alt = (π / 2 - z)u"rad"
                 solar_azimuth = solar_azimuth_angle(h, ϕ, δ)


### PR DESCRIPTION
Preallocate MVectors with the other buffers and remove type instability from using degree units for radian (its not really supported - we should consider removing or fixing Unitful.jl)